### PR TITLE
ci(renovate): auto-merge npm updates without waiting for CI

### DIFF
--- a/.renovate/auto-merge.json5
+++ b/.renovate/auto-merge.json5
@@ -17,5 +17,13 @@
       matchUpdateTypes: ['patch', 'digest'],
       ignoreTests: true,
     },
+    {
+      description: 'Auto-merge npm updates without waiting for CI (no CI runs on npm dependency changes)',
+      matchManagers: ['npm'],
+      automerge: true,
+      automergeType: 'pr',
+      matchUpdateTypes: ['patch', 'minor'],
+      ignoreTests: true,
+    },
   ],
 }


### PR DESCRIPTION
No CI is triggered when npm packages are updated, so requiring tests to
pass prevents auto-merge from completing. Set ignoreTests: true for the
npm manager to allow patch and minor updates to merge automatically.

https://claude.ai/code/session_01DSsrWYV99Q5hN5eQgx1nby