### PR TITLE
fix: map "External fan duty" status key to "external-fans" channel

### DIFF
--- a/src/FanControl.Liquidctl/Utils.cs
+++ b/src/FanControl.Liquidctl/Utils.cs
@@ -13,6 +13,9 @@ namespace FanControl.LiquidCtl
         [GeneratedRegex(@"^pump\s*fan\s*(speed|duty)$", RegexOptions.IgnoreCase)]
         private static partial Regex PumpFanPattern();
 
+        [GeneratedRegex(@"^external\s*fan\s*(speed|duty)$", RegexOptions.IgnoreCase)]
+        private static partial Regex ExternalFanPattern();
+
         [GeneratedRegex(@"^fan\s*(\d+)\s*(speed|duty)$", RegexOptions.IgnoreCase)]
         private static partial Regex MultipleFanPattern();
 
@@ -56,6 +59,11 @@ namespace FanControl.LiquidCtl
             if (PumpFanPattern().IsMatch(statusKey))
             {
                 return "pump-fan";
+            }
+
+            if (ExternalFanPattern().IsMatch(statusKey))
+            {
+                return "external-fans";
             }
 
             var multipleFanMatch = MultipleFanPattern().Match(statusKey);


### PR DESCRIPTION
The ASUS ROG Ryujin II 360 reports an "External fan duty" status for its shared radiator fan channel, which liquidctl exposes as "external-fans". ExtractChannelName had no matching pattern, so it returned the raw status key and liquidctl rejected speed set requests with "invalid channel: External fan duty".

Closes #143