### PR TITLE
feat: RGB command sink (set.led) over a dedicated pipe

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -9,6 +9,7 @@ A FanControl plugin that integrates [liquidctl](https://github.com/liquidctl/liq
 - **Temperature Monitoring**: Real-time fluid temperature readings from your AIO cooler
 - **Pump Control**: Adjust pump speeds with precise duty cycle control
 - **Fan Control**: Monitor and control fan speeds on supported devices
+- **RGB Lighting Endpoint**: Exposes a `set.led` command on a dedicated pipe so an external plugin can drive device lighting through the same serialized HID queue as the fans — no USB contention
 - **Wide Device Support**: Compatible with all [liquidctl supported devices](https://github.com/liquidctl/liquidctl#supported-devices)
 - **Seamless Integration**: Works natively with FanControl's interface
 - **Error Recovery**: Automatic refresh and recovery from communication errors
@@ -54,6 +55,27 @@ Once installed, the plugin automatically:
 
 - **Pump Duty**: Adjust pump speed (percentage-based)
 - **Fan Control**: Control fan speeds (where supported)
+
+## RGB Lighting (command sink)
+
+Besides fans and pumps, the bridge exposes an RGB endpoint so another process can drive device lighting **through this plugin**, sharing the one serialized per-device HID queue — so RGB never contends with fan/pump commands on the same USB device (a separate RGB tool fighting for the same HID is the usual cause of dropped commands and stalled control).
+
+- A **dedicated pipe** `LiquidCtlPipeRgb` (separate from the fan pipe, which a client holds open) accepts the `set.led` command.
+- `set.led` applies per-LED colours to a channel of a device matched by description — e.g. the Kraken `ring`/`logo` or the Smart Device `led1`/`led2`.
+
+```json
+{
+  "command": "set.led",
+  "data": {
+    "device": "Kraken",
+    "channel": "ring",
+    "mode": "super-fixed",
+    "colors": [[255, 0, 0], [0, 255, 0], "... one [r,g,b] per LED"]
+  }
+}
+```
+
+This powers the NZXT command sink in [FanControl.Rgb](https://github.com/6wheels/FanControlPlugins): NZXT RGB reacts to FanControl sensors while liquidctl stays the sole owner of the HID.
 
 ## Screenshots
 

--- a/agents/protocol.md
+++ b/agents/protocol.md
@@ -1,73 +1,105 @@
 # Communication Protocol
 
-## Named Pipes
+## Named pipes
 
-- **Pipe Name:** `liquidctl_<random>`
-- **Message Format:** MessagePack binary
+The bridge serves two Windows named pipes:
+
+- `\\.\pipe\LiquidCtlPipe` — primary pipe (sensors + fan/pump control). The
+  FanControl plugin holds this connection open.
+- `\\.\pipe\LiquidCtlPipeRgb` — dedicated RGB pipe. The pipe server is
+  single-client per instance and the fan client keeps the primary pipe busy, so
+  RGB callers connect here. Both pipes feed the same service, so every command
+  runs on the same per-device serialized HID queue.
+
+Under `--test`, the names gain a `Test` suffix (`LiquidCtlPipeTest`,
+`LiquidCtlPipeTestRgb`).
+
+**Framing:** message-mode pipe, one UTF-8 JSON object per message (encoded/decoded
+with `msgspec`). There is no length prefix.
+
+## Request envelope
+
+```json
+{ "command": "<name>", "data": { /* command-specific, or null */ } }
+```
+
+`data` is decoded per command; omit it or send `null` when a command takes no
+payload.
+
+## Response envelope
+
+```json
+{ "status": "success", "data": <result-or-null>, "error": null }
+```
+
+On failure: `{ "status": "error", "data": null, "error": "<message>" }`.
 
 ## Commands
 
-> Note: Examples show logical structure. Actual wire format is MessagePack binary.
+### `get.statuses`
 
-### Initialize
-
-```json
-{
-  "command": "initialize"
-}
-```
-
-### Get Status
+No `data`. Returns one entry per connected device.
 
 ```json
-{
-  "command": "get_status"
-}
+{ "command": "get.statuses" }
 ```
 
-**Response:**
+Response `data`:
 
 ```json
 [
   {
-    "description": "NZXT Kraken X63",
+    "id": 1,
+    "description": "NZXT Kraken X (X53, X63 or X73)",
     "status": [
-      {
-        "key": "Liquid temperature",
-        "value": 28.5,
-        "unit": "°C"
-      },
-      {
-        "key": "Pump speed",
-        "value": 2500,
-        "unit": "rpm"
-      },
-      {
-        "key": "pump",
-        "value": 75,
-        "unit": "%"
-      }
+      { "key": "Liquid temperature", "value": 28.5, "unit": "°C" },
+      { "key": "Pump speed",         "value": 2500, "unit": "rpm" },
+      { "key": "Pump duty",          "value": 75,   "unit": "%" }
     ]
   }
 ]
 ```
 
-### Set Speed
+### `set.fixed_speed`
+
+Sets a fixed duty on a channel. `device_id` is the 1-based index from
+`get.statuses`.
 
 ```json
 {
-  "command": "set_speed",
-  "device": "NZXT Kraken X63",
-  "channel": "pump",
-  "duty": 80
+  "command": "set.fixed_speed",
+  "data": { "device_id": 1, "speed_kwargs": { "channel": "pump", "duty": 80 } }
 }
 ```
 
-## Error Responses
+Response `data` is `null`.
+
+### `set.led`
+
+Applies per-LED colours to a lighting channel. The device is matched by a
+case-insensitive substring of its description (callers target by name, not by
+id). `colors` is one `[r, g, b]` triple (0–255) per LED on the channel.
 
 ```json
 {
-  "error": "Device not found",
-  "code": "DEVICE_NOT_FOUND"
+  "command": "set.led",
+  "data": {
+    "device": "Kraken",
+    "channel": "ring",
+    "mode": "super-fixed",
+    "colors": [[255, 0, 0], [0, 255, 0], [0, 0, 255]]
+  }
 }
 ```
+
+Response `data` is `null`. Channel names and LED counts are device-specific (e.g.
+Kraken `ring`/`logo`, Smart Device `led1`/`led2`); `mode` is any liquidctl colour
+mode the channel supports (`super-fixed` for a per-LED frame).
+
+## Diagnostics
+
+Set the `LIQUIDCTL_BRIDGE_LOG` environment variable (e.g. `INFO`, `DEBUG`) to
+override the log level without changing the host plugin's spawn arguments. At
+startup the bridge logs a device inventory (descriptions, drivers, colour
+channels, LED counts); `set.led` requests are traced with the resolved device,
+channel, mode, and colour count.

--- a/src/liquidctl_server/liquidctl_server/models.py
+++ b/src/liquidctl_server/liquidctl_server/models.py
@@ -25,9 +25,19 @@ class FixedSpeedRequest(msgspec.Struct):
     speed_kwargs: SpeedKwargs
 
 
+class LedRequest(msgspec.Struct):
+    # device is matched against each liquidctl device's description (the RGB
+    # plugin targets devices by name, not by integer id).
+    device: str
+    channel: str
+    mode: str
+    colors: List[List[int]]
+
+
 class PipeRequest(msgspec.Struct):
     command: str
-    data: Optional[FixedSpeedRequest] = None
+    # Decoded per-command (each command has its own payload shape).
+    data: Optional[msgspec.Raw] = None
 
 
 class BridgeResponse(msgspec.Struct):

--- a/src/liquidctl_server/liquidctl_server/models.py
+++ b/src/liquidctl_server/liquidctl_server/models.py
@@ -36,8 +36,10 @@ class LedRequest(msgspec.Struct):
 
 class PipeRequest(msgspec.Struct):
     command: str
-    # Decoded per-command (each command has its own payload shape).
-    data: Optional[msgspec.Raw] = None
+    # Decoded per-command (each command has its own payload shape). Kept as a
+    # bare Raw, not Optional[Raw]: msgspec drops the Raw arm of Optional[Raw] and
+    # would then reject any non-null data. Absent/null decodes to Raw(b"null").
+    data: msgspec.Raw = msgspec.Raw(b"null")
 
 
 class BridgeResponse(msgspec.Struct):

--- a/src/liquidctl_server/liquidctl_server/server.py
+++ b/src/liquidctl_server/liquidctl_server/server.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import sys
 import threading
 import time
@@ -118,7 +119,10 @@ def main():
     )
     args = parser.parse_args()
 
-    setup_logging(args.log_level)
+    # Env override so the bridge can be made verbose without changing the spawn
+    # args of the host plugin (set LIQUIDCTL_BRIDGE_LOG=DEBUG before launch).
+    log_level = os.environ.get("LIQUIDCTL_BRIDGE_LOG") or args.log_level
+    setup_logging(log_level)
     suffix = "Test" if args.test else ""
     pipe_name = f"LiquidCtlPipe{suffix}"
     # Dedicated pipe for the RGB plugin: the fan client holds its connection open
@@ -135,6 +139,7 @@ def main():
         ):
             logger.info("Initializing Liquidctl devices...")
             service.initialize_all()
+            service.log_device_details()
             logger.info(f"Bridge Server listening on \\\\.\\pipe\\{pipe_name}")
             logger.info(f"RGB Bridge Server listening on \\\\.\\pipe\\{rgb_pipe_name}")
 

--- a/src/liquidctl_server/liquidctl_server/server.py
+++ b/src/liquidctl_server/liquidctl_server/server.py
@@ -3,7 +3,7 @@ import logging
 import sys
 import threading
 import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict
 
 import msgspec
 
@@ -22,17 +22,18 @@ from liquidctl_server.service import LiquidctlService
 logger = logging.getLogger(__name__)
 
 
-def handle_get_statuses(service: LiquidctlService, data: Any) -> Any:
+def _decode_data(data: msgspec.Raw, type_, command: str):
+    if data is None or bytes(data) == b"null":
+        raise BadRequestException(f"Missing data for {command}")
+    return msgspec.json.decode(data, type=type_)
+
+
+def handle_get_statuses(service: LiquidctlService, data: msgspec.Raw) -> Any:
     return service.get_statuses()
 
 
-def handle_set_fixed_speed(
-    service: LiquidctlService, data: Optional[msgspec.Raw]
-) -> Any:
-    if data is None:
-        raise BadRequestException("Missing data for set.fixed_speed")
-
-    request = msgspec.json.decode(data, type=FixedSpeedRequest)
+def handle_set_fixed_speed(service: LiquidctlService, data: msgspec.Raw) -> Any:
+    request = _decode_data(data, FixedSpeedRequest, "set.fixed_speed")
     speed_kwargs = {
         "channel": request.speed_kwargs.channel,
         "duty": request.speed_kwargs.duty,
@@ -40,11 +41,8 @@ def handle_set_fixed_speed(
     return service.set_fixed_speed(request.device_id, speed_kwargs)
 
 
-def handle_set_led(service: LiquidctlService, data: Optional[msgspec.Raw]) -> Any:
-    if data is None:
-        raise BadRequestException("Missing data for set.led")
-
-    request = msgspec.json.decode(data, type=LedRequest)
+def handle_set_led(service: LiquidctlService, data: msgspec.Raw) -> Any:
+    request = _decode_data(data, LedRequest, "set.led")
     colors = [tuple(color) for color in request.colors]
     return service.set_color(request.device, request.channel, request.mode, colors)
 

--- a/src/liquidctl_server/liquidctl_server/server.py
+++ b/src/liquidctl_server/liquidctl_server/server.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import sys
+import threading
 import time
 from typing import Any, Callable, Dict, Optional
 
@@ -10,6 +11,7 @@ from liquidctl_server.models import (
     BadRequestException,
     BridgeResponse,
     FixedSpeedRequest,
+    LedRequest,
     MessageStatus,
     PipeError,
     PipeRequest,
@@ -25,21 +27,32 @@ def handle_get_statuses(service: LiquidctlService, data: Any) -> Any:
 
 
 def handle_set_fixed_speed(
-    service: LiquidctlService, data: Optional[FixedSpeedRequest]
+    service: LiquidctlService, data: Optional[msgspec.Raw]
 ) -> Any:
     if data is None:
         raise BadRequestException("Missing data for set.fixed_speed")
 
+    request = msgspec.json.decode(data, type=FixedSpeedRequest)
     speed_kwargs = {
-        "channel": data.speed_kwargs.channel,
-        "duty": data.speed_kwargs.duty,
+        "channel": request.speed_kwargs.channel,
+        "duty": request.speed_kwargs.duty,
     }
-    return service.set_fixed_speed(data.device_id, speed_kwargs)
+    return service.set_fixed_speed(request.device_id, speed_kwargs)
+
+
+def handle_set_led(service: LiquidctlService, data: Optional[msgspec.Raw]) -> Any:
+    if data is None:
+        raise BadRequestException("Missing data for set.led")
+
+    request = msgspec.json.decode(data, type=LedRequest)
+    colors = [tuple(color) for color in request.colors]
+    return service.set_color(request.device, request.channel, request.mode, colors)
 
 
 COMMAND_HANDLERS: Dict[str, Callable] = {
     "get.statuses": handle_get_statuses,
     "set.fixed_speed": handle_set_fixed_speed,
+    "set.led": handle_set_led,
 }
 
 
@@ -108,13 +121,29 @@ def main():
     args = parser.parse_args()
 
     setup_logging(args.log_level)
-    pipe_name = f"LiquidCtlPipe{'Test' if args.test else ''}"
+    suffix = "Test" if args.test else ""
+    pipe_name = f"LiquidCtlPipe{suffix}"
+    # Dedicated pipe for the RGB plugin: the fan client holds its connection open
+    # persistently and the pipe server is single-client per instance, so RGB needs
+    # its own pipe. Both feed the same service → same per-device DeviceExecutor
+    # queue, so the single-owner-per-HID guarantee is preserved.
+    rgb_pipe_name = f"LiquidCtlPipe{suffix}Rgb"
 
     try:
-        with LiquidctlService() as service, Server(name=pipe_name) as pipe:
+        with (
+            LiquidctlService() as service,
+            Server(name=pipe_name) as pipe,
+            Server(name=rgb_pipe_name) as rgb_pipe,
+        ):
             logger.info("Initializing Liquidctl devices...")
             service.initialize_all()
             logger.info(f"Bridge Server listening on \\\\.\\pipe\\{pipe_name}")
+            logger.info(f"RGB Bridge Server listening on \\\\.\\pipe\\{rgb_pipe_name}")
+
+            rgb_thread = threading.Thread(
+                target=run_server_loop, args=(service, rgb_pipe), daemon=True
+            )
+            rgb_thread.start()
 
             run_server_loop(service, pipe)
 

--- a/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
+++ b/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
@@ -218,6 +218,37 @@ class LiquidctlService:
         except Exception as e:
             logger.error(f"Error setting fixed speed for device #{device_id}: {e}")
 
+    def log_device_details(self) -> None:
+        """Dump everything useful about each device for RGB/debug troubleshooting."""
+        introspect = (
+            "_color_channels",
+            "_color_modes",
+            "_speed_channels",
+            "_mled_count",
+            "_led_count",
+            "_fan_count",
+            "_animation_speeds",
+            "_mled",
+        )
+        logger.info("=== Device inventory (%d device(s)) ===", len(self.devices))
+        for device_id, dev in self.devices.items():
+            logger.info(
+                "Device #%d: %s  [driver=%s, vid=%04x, pid=%04x]",
+                device_id,
+                dev.description,
+                type(dev).__name__,
+                getattr(dev, "vendor_id", 0) or 0,
+                getattr(dev, "product_id", 0) or 0,
+            )
+            for attr in introspect:
+                if hasattr(dev, attr):
+                    try:
+                        value = getattr(dev, attr)
+                    except Exception as exc:  # pragma: no cover - defensive
+                        value = f"<error: {exc}>"
+                    logger.info("    %s = %r", attr, value)
+        logger.info("=== End device inventory ===")
+
     def _resolve_device_id(self, device_match: str) -> Optional[int]:
         """Find a device id whose description contains device_match (case-insensitive)."""
         needle = device_match.lower()
@@ -234,12 +265,26 @@ class LiquidctlService:
         colors: List[Tuple[int, int, int]],
     ) -> None:
         """Set per-LED colors for a device channel via the serialized queue."""
+        logger.info(
+            "set_color RX: device_match=%r channel=%r mode=%r ncolors=%d first=%s last=%s",
+            device_match,
+            channel,
+            mode,
+            len(colors),
+            colors[0] if colors else None,
+            colors[-1] if colors else None,
+        )
+
         device_id = self._resolve_device_id(device_match)
         if device_id is None:
+            known = [d.description for d in self.devices.values()]
+            logger.error("set_color: no device matching %r (known: %s)", device_match, known)
             raise BadRequestException(f"No device matching '{device_match}'")
 
+        lc_device = self.devices[device_id]
+        logger.info("set_color: resolved device #%d -> %s", device_id, lc_device.description)
+
         try:
-            lc_device = self.devices[device_id]
             color_job = self._executor.submit(
                 device_id,
                 lc_device.set_color,
@@ -248,11 +293,21 @@ class LiquidctlService:
                 colors=colors,
             )
             color_job.result(timeout=DEVICE_OPERATION_TIMEOUT)
+            logger.info(
+                "set_color: applied channel=%r mode=%r on device #%d", channel, mode, device_id
+            )
 
         except FuturesTimeoutError:
             logger.error(f"Timeout setting color for device #{device_id}")
         except Exception as e:
-            logger.error(f"Error setting color for device #{device_id}: {e}")
+            logger.exception(
+                "set_color FAILED on device #%d (channel=%r mode=%r ncolors=%d): %s",
+                device_id,
+                channel,
+                mode,
+                len(colors),
+                e,
+            )
 
     def disconnect_all(self) -> None:
         """Disconnect all devices."""

--- a/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
+++ b/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
@@ -218,6 +218,42 @@ class LiquidctlService:
         except Exception as e:
             logger.error(f"Error setting fixed speed for device #{device_id}: {e}")
 
+    def _resolve_device_id(self, device_match: str) -> Optional[int]:
+        """Find a device id whose description contains device_match (case-insensitive)."""
+        needle = device_match.lower()
+        for device_id, lc_device in self.devices.items():
+            if needle in lc_device.description.lower():
+                return device_id
+        return None
+
+    def set_color(
+        self,
+        device_match: str,
+        channel: str,
+        mode: str,
+        colors: List[Tuple[int, int, int]],
+    ) -> None:
+        """Set per-LED colors for a device channel via the serialized queue."""
+        device_id = self._resolve_device_id(device_match)
+        if device_id is None:
+            raise BadRequestException(f"No device matching '{device_match}'")
+
+        try:
+            lc_device = self.devices[device_id]
+            color_job = self._executor.submit(
+                device_id,
+                lc_device.set_color,
+                channel=channel,
+                mode=mode,
+                colors=colors,
+            )
+            color_job.result(timeout=DEVICE_OPERATION_TIMEOUT)
+
+        except FuturesTimeoutError:
+            logger.error(f"Timeout setting color for device #{device_id}")
+        except Exception as e:
+            logger.error(f"Error setting color for device #{device_id}: {e}")
+
     def disconnect_all(self) -> None:
         """Disconnect all devices."""
         for device_id, lc_device in self.devices.items():

--- a/src/liquidctl_server/tests/test_client.py
+++ b/src/liquidctl_server/tests/test_client.py
@@ -5,7 +5,7 @@ from ctypes import wintypes
 
 import msgspec
 
-from liquidctl_server.models import BridgeResponse, FixedSpeedRequest, PipeRequest
+from liquidctl_server.models import BridgeResponse, PipeRequest
 from liquidctl_server.pipe_server import (
     INVALID_HANDLE_VALUE,
     KERNEL32,
@@ -84,14 +84,14 @@ class TestClient(Base):
         self.close()
         return False
 
-    def sendRequest(
-        self, command: str, data: FixedSpeedRequest | None = None, timeout: float = 5.0
-    ):
+    def sendRequest(self, command: str, data=None, timeout: float = 5.0):
         """Sends a request and returns the decoded BridgeResponse."""
         if not self.alive:
             raise PipeError("Client is not connected")
 
-        req = PipeRequest(command=command, data=data)
+        # data is decoded per-command on the server, so pre-encode it as Raw.
+        raw = msgspec.Raw(msgspec.json.encode(data)) if data is not None else None
+        req = PipeRequest(command=command, data=raw)
         encoded_bytes = msgspec.json.encode(req)
 
         if not self.write(encoded_bytes):


### PR DESCRIPTION
Adds an RGB command path so an external FanControl plugin can drive NZXT lighting **through this bridge**, sharing the same per-device serialized HID queue as the fan/pump commands. This avoids USB contention when another process (e.g. OpenRGB) would otherwise fight for the same NZXT HID.

## What it adds
- **`set.led` command** — `super-fixed` per-LED colours; device resolved by description match (callers target by name, not integer id). Routed through the existing `DeviceExecutor`, so RGB and fan commands stay serialized on one HID.
- **Dedicated RGB pipe** `LiquidCtlPipe[Test]Rgb` served by a second loop. The pipe server is single-client per instance and the fan client holds the primary pipe open, so RGB needs its own pipe; both share one `LiquidctlService`/queue.
- **Per-command data decoding** — `PipeRequest.data` is now a bare `msgspec.Raw` (decoded per command), since commands carry different payload shapes. Note: `Optional[msgspec.Raw]` is intentionally avoided — msgspec drops the `Raw` arm and would reject any non-null data.
- **Diagnostics** — startup device inventory dump (channels, LED counts) and `set_color` tracing, plus a `LIQUIDCTL_BRIDGE_LOG` env override.

## Compatibility
- Existing `get.statuses` / `set.fixed_speed` behaviour unchanged (the test client wraps `data` as `Raw`).
- No change required for consumers that don't use RGB.

Validated end-to-end against an NZXT Kraken X63 (ring/logo) and Smart Device V2 (led1/led2) with the [FanControl RGB plugin.](https://github.com/6wheels/FanControlPlugins/tree/feat/nzxt-rgb-sink/FanControl.Rgb)