### PR TITLE
feat: control rpm-only fans via authoritative channel enumeration

### DIFF
--- a/src/FanControl.Liquidctl.Tests/UtilsTests.cs
+++ b/src/FanControl.Liquidctl.Tests/UtilsTests.cs
@@ -198,4 +198,24 @@ namespace FanControl.LiquidCtl.Tests
             Assert.Equal("fan1", Utils.ExtractChannelName("Fan 1 speed"));
         }
     }
+
+    public sealed class UtilsGetDutyKeyFromSpeedKeyTests
+    {
+        [Theory]
+        // Real speed (rpm) keys -> their paired duty key
+        [InlineData("Pump speed", "Pump duty")]
+        [InlineData("Fan 1 speed", "Fan 1 duty")]
+        [InlineData("Water block speed", "Water block duty")]
+        [InlineData("Pump fan speed", "Pump fan duty")]
+        [InlineData("External fan speed", "External fan duty")]
+        [InlineData("Fan speed 1", "Fan duty 1")] // Corsair Commander Core ordering
+        // No "speed" present -> passthrough
+        [InlineData("Liquid temperature", "Liquid temperature")]
+        [InlineData("", "")]
+        public void GetDutyKeyFromSpeedKey_ReplacesSpeedWordBoundaryWithDuty(
+            string speedKey, string expected)
+        {
+            Assert.Equal(expected, Utils.GetDutyKeyFromSpeedKey(speedKey));
+        }
+    }
 }

--- a/src/FanControl.Liquidctl/LiquidctlDevice.cs
+++ b/src/FanControl.Liquidctl/LiquidctlDevice.cs
@@ -33,12 +33,12 @@ namespace FanControl.LiquidCtl
 
         public string? PairedFanSensorId { get; }
 
-        internal ControlSensor(DeviceStatus device, StatusValue channel, LiquidctlClient liquidctl, string? pairedFanSensorId) :
+        internal ControlSensor(DeviceStatus device, StatusValue channel, LiquidctlClient liquidctl, string? pairedFanSensorId, string? explicitChannelName = null) :
             base(device, channel)
         {
             Initial = Value;
             this.liquidctl = liquidctl;
-            channelName = Utils.ExtractChannelName(channel.Key);
+            channelName = explicitChannelName ?? Utils.ExtractChannelName(channel.Key);
             PairedFanSensorId = pairedFanSensorId;
         }
 

--- a/src/FanControl.Liquidctl/LiquidctlPlugin.cs
+++ b/src/FanControl.Liquidctl/LiquidctlPlugin.cs
@@ -32,6 +32,29 @@ namespace FanControl.LiquidCtl
                 {
                     ProcessChannel(device, channel, _container);
                 }
+
+                AddAuthoritativeControls(device, _container);
+            }
+        }
+
+        private void AddAuthoritativeControls(DeviceStatus device, IPluginSensorsContainer container)
+        {
+            foreach (string channelName in device.SpeedChannels)
+            {
+                if (device.Status.Any(s => s.Unit == "%" && Utils.ExtractChannelName(s.Key) == channelName))
+                {
+                    continue;
+                }
+
+                StatusValue? speed = device.Status.FirstOrDefault(
+                    s => s.Unit == "rpm" && Utils.ExtractChannelName(s.Key) == channelName);
+                string dutyKey = speed != null ? Utils.GetDutyKeyFromSpeedKey(speed.Key) : channelName;
+
+                StatusValue dutyChannel = new() { Key = dutyKey, Value = null, Unit = "%" };
+                string pairedId = Utils.CreateSensorId(device.Description, Utils.GetSpeedKeyFromDutyKey(dutyKey));
+                ControlSensor sensor = new(device, dutyChannel, liquidctl, pairedId, explicitChannelName: channelName);
+                sensors[sensor.Id] = sensor;
+                container.ControlSensors.Add(sensor);
             }
         }
 

--- a/src/FanControl.Liquidctl/Models.cs
+++ b/src/FanControl.Liquidctl/Models.cs
@@ -95,6 +95,9 @@ namespace FanControl.LiquidCtl
 
         [JsonPropertyName("status")]
         public required IReadOnlyList<StatusValue> Status { get; init; }
+
+        [JsonPropertyName("speed_channels")]
+        public IReadOnlyList<string> SpeedChannels { get; init; } = [];
     }
 
     internal sealed class CachedStatuses(IReadOnlyList<DeviceStatus> statuses)

--- a/src/FanControl.Liquidctl/Utils.cs
+++ b/src/FanControl.Liquidctl/Utils.cs
@@ -28,6 +28,9 @@ namespace FanControl.LiquidCtl
         [GeneratedRegex(@"\bduty\b", RegexOptions.IgnoreCase)]
         private static partial Regex DutyWordPattern();
 
+        [GeneratedRegex(@"\bspeed\b", RegexOptions.IgnoreCase)]
+        private static partial Regex SpeedWordPattern();
+
         [GeneratedRegex(@"\s*duty\s*", RegexOptions.IgnoreCase)]
         private static partial Regex DutyWithSpacesPattern();
 
@@ -92,6 +95,11 @@ namespace FanControl.LiquidCtl
         public static string GetSpeedKeyFromDutyKey(string dutyKey)
         {
             return DutyWordPattern().Replace(dutyKey, "speed");
+        }
+
+        public static string GetDutyKeyFromSpeedKey(string speedKey)
+        {
+            return SpeedWordPattern().Replace(speedKey, "duty");
         }
     }
 }

--- a/src/liquidctl_server/liquidctl_server/models.py
+++ b/src/liquidctl_server/liquidctl_server/models.py
@@ -48,6 +48,7 @@ class DeviceStatus(msgspec.Struct):
     id: int
     description: str
     status: List[StatusValue]
+    speed_channels: List[str] = []
 
 
 class Mode(IntEnum):

--- a/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
+++ b/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
@@ -3,12 +3,25 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Dict, List, Optional, Tuple, Union
 
 import liquidctl
-from liquidctl.driver.aquacomputer import Aquacomputer
 from liquidctl.driver.base import BaseDriver
-from liquidctl.driver.commander_core import CommanderCore
 from liquidctl.driver.commander_pro import CommanderPro
 from liquidctl.driver.hydro_platinum import HydroPlatinum
-from liquidctl.driver.smart_device import H1V2, SmartDevice, SmartDevice2
+from liquidctl.driver.smart_device import SmartDevice, SmartDevice2
+
+try:
+    from liquidctl.driver.aquacomputer import Aquacomputer
+except ImportError:
+    Aquacomputer = None
+
+try:
+    from liquidctl.driver.commander_core import CommanderCore
+except ImportError:
+    CommanderCore = None
+
+try:
+    from liquidctl.driver.smart_device import H1V2
+except ImportError:
+    H1V2 = None
 
 try:
     from liquidctl.driver.smart_device import ControlHub
@@ -255,18 +268,25 @@ class LiquidctlService:
     @staticmethod
     def _get_speed_channels(lc_device: BaseDriver) -> List[str]:
         """Controllable speed channels reported by the driver (no uniform API exists)."""
-        if isinstance(lc_device, (SmartDevice2, SmartDevice, H1V2)) or (
-            ControlHub is not None and isinstance(lc_device, ControlHub)
+
+        def is_a(driver_cls) -> bool:
+            return driver_cls is not None and isinstance(lc_device, driver_cls)
+
+        if (
+            isinstance(lc_device, (SmartDevice2, SmartDevice))
+            or is_a(ControlHub)
+            or is_a(H1V2)
         ):
             return list(getattr(lc_device, "_speed_channels", {}).keys())
-        if isinstance(lc_device, Aquacomputer):
-            device_info = getattr(lc_device, "_device_info", {})
-            return list(device_info.get("fan_ctrl", {}).keys())
-        if isinstance(lc_device, CommanderCore):
+        if is_a(Aquacomputer):
+            return list(
+                getattr(lc_device, "_device_info", {}).get("fan_ctrl", {}).keys()
+            )
+        if is_a(CommanderCore):
             return ["pump"] if getattr(lc_device, "_has_pump", False) else []
         if isinstance(lc_device, (CommanderPro, HydroPlatinum)):
             return list(getattr(lc_device, "_fan_names", []))
-        if HydroPro is not None and isinstance(lc_device, HydroPro):
+        if is_a(HydroPro):
             return [f"fan{i + 1}" for i in range(getattr(lc_device, "_fan_count", 0))]
         return []
 

--- a/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
+++ b/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
@@ -3,7 +3,22 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Dict, List, Optional, Tuple, Union
 
 import liquidctl
+from liquidctl.driver.aquacomputer import Aquacomputer
 from liquidctl.driver.base import BaseDriver
+from liquidctl.driver.commander_core import CommanderCore
+from liquidctl.driver.commander_pro import CommanderPro
+from liquidctl.driver.hydro_platinum import HydroPlatinum
+from liquidctl.driver.smart_device import H1V2, SmartDevice, SmartDevice2
+
+try:
+    from liquidctl.driver.smart_device import ControlHub
+except ImportError:
+    ControlHub = None
+
+try:
+    from liquidctl.driver.hydro_pro import HydroPro
+except ImportError:
+    HydroPro = None
 
 from liquidctl_server.models import (
     BadRequestException,
@@ -27,6 +42,7 @@ class LiquidctlService:
     def __init__(self) -> None:
         self.devices: Dict[int, BaseDriver] = {}
         self.device_status_cache: Dict[int, List[StatusValue]] = {}
+        self.speed_channels: Dict[int, List[str]] = {}
         self.previous_duty: Dict[str, Union[str, int, None]] = {}
         self._executor: DeviceExecutor = DeviceExecutor()
 
@@ -94,6 +110,8 @@ class LiquidctlService:
             init_job = self._executor.submit(device_id, lc_device.initialize)
             init_job.result(timeout=DEVICE_OPERATION_TIMEOUT)
 
+            self.speed_channels[device_id] = self._get_speed_channels(lc_device)
+
         except RuntimeError as err:
             if "already open" in str(err):
                 logger.warning(f"Device #{device_id} already connected")
@@ -123,11 +141,7 @@ class LiquidctlService:
             status_values = self._stringify_status(raw_status)
             self.device_status_cache[device_id] = status_values
 
-            return DeviceStatus(
-                id=device_id,
-                description=lc_device.description,
-                status=status_values,
-            )
+            return self._build_device_status(device_id, lc_device, status_values)
 
         except FuturesTimeoutError:
             return self._handle_status_timeout(device_id, lc_device)
@@ -171,11 +185,7 @@ class LiquidctlService:
         status_values = self._stringify_status(raw_status)
         self.device_status_cache[device_id] = status_values
 
-        return DeviceStatus(
-            id=device_id,
-            description=lc_device.description,
-            status=status_values,
-        )
+        return self._build_device_status(device_id, lc_device, status_values)
 
     def _build_status_from_cache(
         self, device_id: int, lc_device: BaseDriver
@@ -185,10 +195,16 @@ class LiquidctlService:
         if cached is None:
             return None
 
+        return self._build_device_status(device_id, lc_device, cached)
+
+    def _build_device_status(
+        self, device_id: int, lc_device: BaseDriver, status_values: List[StatusValue]
+    ) -> DeviceStatus:
         return DeviceStatus(
             id=device_id,
             description=lc_device.description,
-            status=cached,
+            status=status_values,
+            speed_channels=self.speed_channels.get(device_id, []),
         )
 
     def set_fixed_speed(
@@ -233,7 +249,26 @@ class LiquidctlService:
         self._executor.shutdown()
         self.devices.clear()
         self.device_status_cache.clear()
+        self.speed_channels.clear()
         self.previous_duty.clear()
+
+    @staticmethod
+    def _get_speed_channels(lc_device: BaseDriver) -> List[str]:
+        """Controllable speed channels reported by the driver (no uniform API exists)."""
+        if isinstance(lc_device, (SmartDevice2, SmartDevice, H1V2)) or (
+            ControlHub is not None and isinstance(lc_device, ControlHub)
+        ):
+            return list(getattr(lc_device, "_speed_channels", {}).keys())
+        if isinstance(lc_device, Aquacomputer):
+            device_info = getattr(lc_device, "_device_info", {})
+            return list(device_info.get("fan_ctrl", {}).keys())
+        if isinstance(lc_device, CommanderCore):
+            return ["pump"] if getattr(lc_device, "_has_pump", False) else []
+        if isinstance(lc_device, (CommanderPro, HydroPlatinum)):
+            return list(getattr(lc_device, "_fan_names", []))
+        if HydroPro is not None and isinstance(lc_device, HydroPro):
+            return [f"fan{i + 1}" for i in range(getattr(lc_device, "_fan_count", 0))]
+        return []
 
     @staticmethod
     def _stringify_status(
@@ -247,7 +282,7 @@ class LiquidctlService:
         for status in statuses:
             try:
                 value = float(status[1])
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 value = None
 
             result.append(

--- a/src/liquidctl_server/tests/test_speed_channels.py
+++ b/src/liquidctl_server/tests/test_speed_channels.py
@@ -1,0 +1,41 @@
+from liquidctl.driver.commander_core import CommanderCore
+from liquidctl.driver.commander_pro import CommanderPro
+
+from liquidctl_server.service.liquidctl_service import LiquidctlService
+
+
+def _fake(driver_cls, **attrs):
+    instance = driver_cls.__new__(driver_cls)
+    for name, value in attrs.items():
+        setattr(instance, name, value)
+    return instance
+
+
+def test_commander_pro_uses_fan_names():
+    device = _fake(CommanderPro, _fan_names=["fan1", "fan2", "fan3"])
+    assert LiquidctlService._get_speed_channels(device) == ["fan1", "fan2", "fan3"]
+
+
+def test_commander_core_pump_gated_on_has_pump():
+    assert LiquidctlService._get_speed_channels(
+        _fake(CommanderCore, _has_pump=True)
+    ) == ["pump"]
+    assert (
+        LiquidctlService._get_speed_channels(_fake(CommanderCore, _has_pump=False))
+        == []
+    )
+
+
+def test_unknown_device_has_no_speed_channels():
+    assert LiquidctlService._get_speed_channels(object()) == []
+
+
+def main():
+    test_commander_pro_uses_fan_names()
+    test_commander_core_pump_gated_on_has_pump()
+    test_unknown_device_has_no_speed_channels()
+    print("test_speed_channels: OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #182. The plugin decided controllability purely from a channel's unit ("%" duty -> control, "rpm" -> read-only). The Corsair Commander Pro reports its fans only as RPM with no duty channel, so every fan became a read-only sensor despite the hardware being controllable.

liquidctl exposes no uniform capability API, so (mirroring CoolerControl's liqctld) the Python bridge now reads the controllable speed channels per driver family (CommanderPro/HydroPlatinum _fan_names, Aquacomputer fan_ctrl, SmartDevice _speed_channels, CommanderCore pump, HydroPro fan_count) and ships them as speed_channels in the device payload.

The C# plugin keeps the existing duty-based control path and additionally creates a control for any enumerated channel lacking a "%" duty channel, paired to its RPM reading. No duty is reported for these, so the control's value/initial are null and Reset is a no-op; FanControl drives it via Set, issuing `set <channel> speed <0-100>`.