### PR TITLE
test: expand Python and .NET test coverage

### DIFF
--- a/src/FanControl.Liquidctl.Tests/DeviceSensorTests.cs
+++ b/src/FanControl.Liquidctl.Tests/DeviceSensorTests.cs
@@ -66,3 +66,69 @@ public sealed class DeviceSensorTests
         Assert.Equal(900f, sensor.Value);
     }
 }
+
+public sealed class ControlSensorTests
+{
+    private static DeviceStatus MakeDevice(string description = "NZXT Kraken X63") =>
+        new() { Id = 1, Description = description, Status = [] };
+
+    private static StatusValue MakeStatus(string key = "fan1 duty", double? value = 50.0, string unit = "%") =>
+        new() { Key = key, Value = value, Unit = unit };
+
+    [WindowsOnlyFact]
+    public void Set_SendsCorrectDeviceIdAndDuty()
+    {
+        using var client = new FakeLiquidctlClient();
+        var sensor = new ControlSensor(MakeDevice(), MakeStatus(), client, pairedFanSensorId: null, explicitChannelName: "fan1");
+
+        sensor.Set(75.0f);
+
+        Assert.Single(client.SpeedRequests);
+        Assert.Equal(1, client.SpeedRequests[0].DeviceId);
+        Assert.Equal(75, client.SpeedRequests[0].SpeedKwargs.Duty);
+        Assert.Equal("fan1", client.SpeedRequests[0].SpeedKwargs.Channel);
+    }
+
+    [WindowsOnlyFact]
+    public void Set_RoundsFloatDuty()
+    {
+        using var client = new FakeLiquidctlClient();
+        var sensor = new ControlSensor(MakeDevice(), MakeStatus(), client, null, "fan1");
+
+        sensor.Set(49.7f);
+
+        Assert.Equal(50, client.SpeedRequests[0].SpeedKwargs.Duty);
+    }
+
+    [WindowsOnlyFact]
+    public void Reset_CallsSetWithInitialValue()
+    {
+        using var client = new FakeLiquidctlClient();
+        var sensor = new ControlSensor(MakeDevice(), MakeStatus(value: 60.0), client, null, "pump");
+
+        sensor.Reset();
+
+        Assert.Single(client.SpeedRequests);
+        Assert.Equal(60, client.SpeedRequests[0].SpeedKwargs.Duty);
+    }
+
+    [WindowsOnlyFact]
+    public void Reset_NullInitialValue_DoesNothing()
+    {
+        using var client = new FakeLiquidctlClient();
+        var sensor = new ControlSensor(MakeDevice(), MakeStatus(value: null), client, null, "pump");
+
+        sensor.Reset();
+
+        Assert.Empty(client.SpeedRequests);
+    }
+
+    [WindowsOnlyFact]
+    public void PairedFanSensorId_IsSetCorrectly()
+    {
+        using var client = new FakeLiquidctlClient();
+        var sensor = new ControlSensor(MakeDevice(), MakeStatus(), client, "NZXTKrakenX63/Fan1speed");
+
+        Assert.Equal("NZXTKrakenX63/Fan1speed", sensor.PairedFanSensorId);
+    }
+}

--- a/src/FanControl.Liquidctl.Tests/LiquidctlPluginTests.cs
+++ b/src/FanControl.Liquidctl.Tests/LiquidctlPluginTests.cs
@@ -1,0 +1,192 @@
+using FanControl.Plugins;
+using Xunit;
+
+namespace FanControl.LiquidCtl.Tests;
+
+internal sealed class FakeLiquidctlClient : ILiquidctlClient
+{
+    public bool Disposed { get; private set; }
+    public bool InitCalled { get; private set; }
+    public List<FixedSpeedRequest> SpeedRequests { get; } = [];
+    public IReadOnlyList<DeviceStatus> StatusesToReturn { get; set; } = [];
+
+    public void Init() => InitCalled = true;
+    public IReadOnlyList<DeviceStatus> GetStatuses() => StatusesToReturn;
+    public void SetFixedSpeed(FixedSpeedRequest req) => SpeedRequests.Add(req);
+    public void Dispose() => Disposed = true;
+}
+
+internal sealed class FakeContainer : IPluginSensorsContainer
+{
+    public List<IPluginControlSensor> ControlSensors { get; } = [];
+    public List<IPluginSensor> FanSensors { get; } = [];
+    public List<IPluginSensor> TempSensors { get; } = [];
+}
+
+public sealed class LiquidctlPluginTests
+{
+    private static DeviceStatus MakeDevice(
+        string description = "NZXT Kraken X63",
+        IReadOnlyList<StatusValue>? status = null,
+        IReadOnlyList<string>? speedChannels = null) =>
+        new() { Id = 1, Description = description, Status = status ?? [], SpeedChannels = speedChannels ?? [] };
+
+    private static StatusValue MakeStatus(string key = "Fan 1 speed", double? value = 1200.0, string unit = "rpm") =>
+        new() { Key = key, Value = value, Unit = unit };
+
+    [WindowsOnlyFact]
+    public void Initialize_CallsInit()
+    {
+        using var client = new FakeLiquidctlClient();
+        using var plugin = new LiquidCtlPlugin(client);
+
+        plugin.Initialize();
+
+        Assert.True(client.InitCalled);
+    }
+
+    [WindowsOnlyFact]
+    public void Close_CallsDispose()
+    {
+        using var client = new FakeLiquidctlClient();
+        using var plugin = new LiquidCtlPlugin(client);
+
+        plugin.Close();
+
+        Assert.True(client.Disposed);
+    }
+
+    [WindowsOnlyFact]
+    public void Dispose_CallsClientDispose()
+    {
+        using var client = new FakeLiquidctlClient();
+        var plugin = new LiquidCtlPlugin(client);
+
+        plugin.Dispose();
+
+        Assert.True(client.Disposed);
+    }
+
+    [WindowsOnlyFact]
+    public void Update_EmptySensors_DoesNotThrow()
+    {
+        using var client = new FakeLiquidctlClient { StatusesToReturn = [MakeDevice(status: [MakeStatus()])] };
+        using var plugin = new LiquidCtlPlugin(client);
+
+        var ex = Record.Exception(plugin.Update);
+
+        Assert.Null(ex);
+    }
+
+    [WindowsOnlyFact]
+    public void Load_NoDevices_ContainerIsEmpty()
+    {
+        using var client = new FakeLiquidctlClient();
+        using var plugin = new LiquidCtlPlugin(client);
+        var container = new FakeContainer();
+
+        plugin.Load(container);
+
+        Assert.Empty(container.FanSensors);
+        Assert.Empty(container.TempSensors);
+        Assert.Empty(container.ControlSensors);
+    }
+
+    [WindowsOnlyFact]
+    public void Load_TempChannel_AddsTempSensor()
+    {
+        using var client = new FakeLiquidctlClient
+        {
+            StatusesToReturn = [MakeDevice(status: [MakeStatus(key: "Liquid temperature", value: 27.5, unit: "°C")])]
+        };
+        using var plugin = new LiquidCtlPlugin(client);
+        var container = new FakeContainer();
+
+        plugin.Load(container);
+
+        Assert.Single(container.TempSensors);
+        Assert.Empty(container.FanSensors);
+        Assert.Empty(container.ControlSensors);
+    }
+
+    [WindowsOnlyFact]
+    public void Load_FanChannel_AddsFanSensor()
+    {
+        using var client = new FakeLiquidctlClient
+        {
+            StatusesToReturn = [MakeDevice(status: [MakeStatus(key: "Fan 1 speed", value: 1200.0, unit: "rpm")])]
+        };
+        using var plugin = new LiquidCtlPlugin(client);
+        var container = new FakeContainer();
+
+        plugin.Load(container);
+
+        Assert.Single(container.FanSensors);
+        Assert.Empty(container.TempSensors);
+        Assert.Empty(container.ControlSensors);
+    }
+
+    [WindowsOnlyFact]
+    public void Load_DutyChannel_AddsControlSensor()
+    {
+        using var client = new FakeLiquidctlClient
+        {
+            StatusesToReturn = [MakeDevice(status: [MakeStatus(key: "Fan 1 duty", value: 50.0, unit: "%")])]
+        };
+        using var plugin = new LiquidCtlPlugin(client);
+        var container = new FakeContainer();
+
+        plugin.Load(container);
+
+        Assert.Single(container.ControlSensors);
+        Assert.Empty(container.FanSensors);
+        Assert.Empty(container.TempSensors);
+    }
+
+    [WindowsOnlyFact]
+    public void Load_NullChannelValue_SkipsSensor()
+    {
+        using var client = new FakeLiquidctlClient
+        {
+            StatusesToReturn = [MakeDevice(status: [MakeStatus(key: "Fan 1 speed", value: null, unit: "rpm")])]
+        };
+        using var plugin = new LiquidCtlPlugin(client);
+        var container = new FakeContainer();
+
+        plugin.Load(container);
+
+        Assert.Empty(container.FanSensors);
+    }
+
+    [WindowsOnlyFact]
+    public void Load_SpeedChannelNotInStatus_AddsAuthoritativeControl()
+    {
+        using var client = new FakeLiquidctlClient
+        {
+            StatusesToReturn = [MakeDevice(status: [], speedChannels: ["fan1"])]
+        };
+        using var plugin = new LiquidCtlPlugin(client);
+        var container = new FakeContainer();
+
+        plugin.Load(container);
+
+        Assert.Single(container.ControlSensors);
+    }
+
+    [WindowsOnlyFact]
+    public void Update_AfterLoad_UpdatesSensorValue()
+    {
+        using var client = new FakeLiquidctlClient
+        {
+            StatusesToReturn = [MakeDevice(status: [MakeStatus(key: "Liquid temperature", value: 27.0, unit: "°C")])]
+        };
+        using var plugin = new LiquidCtlPlugin(client);
+        var container = new FakeContainer();
+        plugin.Load(container);
+
+        client.StatusesToReturn = [MakeDevice(status: [MakeStatus(key: "Liquid temperature", value: 30.0, unit: "°C")])];
+        plugin.Update();
+
+        Assert.Equal(30.0f, container.TempSensors[0].Value);
+    }
+}

--- a/src/FanControl.Liquidctl/ILiquidctlClient.cs
+++ b/src/FanControl.Liquidctl/ILiquidctlClient.cs
@@ -1,0 +1,9 @@
+namespace FanControl.LiquidCtl
+{
+    internal interface ILiquidctlClient : IDisposable
+    {
+        void Init();
+        IReadOnlyList<DeviceStatus> GetStatuses();
+        void SetFixedSpeed(FixedSpeedRequest request);
+    }
+}

--- a/src/FanControl.Liquidctl/LiquidctlClient.cs
+++ b/src/FanControl.Liquidctl/LiquidctlClient.cs
@@ -8,7 +8,7 @@ using FanControl.Plugins;
 
 namespace FanControl.LiquidCtl
 {
-    public sealed class LiquidctlClient(IPluginLogger logger) : IDisposable
+    public sealed class LiquidctlClient(IPluginLogger logger) : ILiquidctlClient
     {
         private readonly IPluginLogger _logger = logger;
         private readonly string _exePath = ResolveExePath();

--- a/src/FanControl.Liquidctl/LiquidctlDevice.cs
+++ b/src/FanControl.Liquidctl/LiquidctlDevice.cs
@@ -28,12 +28,12 @@ namespace FanControl.LiquidCtl
     public class ControlSensor : DeviceSensor, IPluginControlSensor2
     {
         internal float? Initial { get; }
-        private readonly LiquidctlClient liquidctl;
+        private readonly ILiquidctlClient liquidctl;
         private readonly string channelName;
 
         public string? PairedFanSensorId { get; }
 
-        internal ControlSensor(DeviceStatus device, StatusValue channel, LiquidctlClient liquidctl, string? pairedFanSensorId, string? explicitChannelName = null) :
+        internal ControlSensor(DeviceStatus device, StatusValue channel, ILiquidctlClient liquidctl, string? pairedFanSensorId, string? explicitChannelName = null) :
             base(device, channel)
         {
             Initial = Value;

--- a/src/FanControl.Liquidctl/LiquidctlPlugin.cs
+++ b/src/FanControl.Liquidctl/LiquidctlPlugin.cs
@@ -2,13 +2,20 @@ using FanControl.Plugins;
 
 namespace FanControl.LiquidCtl
 {
-    public class LiquidCtlPlugin(IPluginLogger logger) : IPlugin2, IDisposable
+    public class LiquidCtlPlugin : IPlugin2, IDisposable
     {
         public string Name => "liquidctl";
 
         private readonly Dictionary<string, DeviceSensor> sensors = [];
-        private readonly LiquidctlClient liquidctl = new(logger);
+        private readonly ILiquidctlClient liquidctl;
         private bool _disposed;
+
+        public LiquidCtlPlugin(IPluginLogger logger) : this(new LiquidctlClient(logger)) { }
+
+        internal LiquidCtlPlugin(ILiquidctlClient client)
+        {
+            liquidctl = client;
+        }
 
         public void Close()
         {

--- a/src/liquidctl_server/tests/test_executor.py
+++ b/src/liquidctl_server/tests/test_executor.py
@@ -37,6 +37,44 @@ class TestDeviceQueueEmpty:
         assert executor.device_queue_empty(999) is True
 
 
+class TestSetNumberOfDevices:
+    def test_creates_queue_per_device(self):
+        executor = DeviceExecutor()
+        executor.set_number_of_devices(3)
+        try:
+            assert executor.device_queue_empty(1) is True
+            assert executor.device_queue_empty(2) is True
+            assert executor.device_queue_empty(3) is True
+        finally:
+            executor.shutdown()
+
+    def test_zero_devices_creates_no_queues(self):
+        executor = DeviceExecutor()
+        executor.set_number_of_devices(0)
+        assert executor.device_queue_empty(1) is True
+
+
+class TestSubmitAndShutdown:
+    def test_submit_runs_job_and_returns_result(self):
+        executor = DeviceExecutor()
+        executor.set_number_of_devices(1)
+        try:
+            future = executor.submit(1, lambda x: x + 1, x=41)
+            assert future.result(timeout=2.0) == 42
+        finally:
+            executor.shutdown()
+
+    def test_shutdown_drains_and_joins(self):
+        executor = DeviceExecutor()
+        executor.set_number_of_devices(2)
+        executor.submit(1, lambda: None)
+        executor.submit(2, lambda: None)
+
+        executor.shutdown()
+
+        assert executor.device_queue_empty(1) is True
+
+
 class TestQueueWorker:
     def test_none_sentinel_terminates_worker(self):
         q = queue.SimpleQueue()

--- a/src/liquidctl_server/tests/test_models.py
+++ b/src/liquidctl_server/tests/test_models.py
@@ -1,4 +1,128 @@
-from liquidctl_server.models import Mode
+import pytest
+import msgspec
+
+from liquidctl_server.models import (
+    BadRequestException,
+    BridgeResponse,
+    DeviceStatus,
+    FixedSpeedRequest,
+    LedRequest,
+    LiquidctlException,
+    MessageStatus,
+    Mode,
+    PipeError,
+    PipeRequest,
+    SpeedKwargs,
+    StatusValue,
+)
+
+
+class TestStatusValue:
+    def test_fields(self):
+        sv = StatusValue(key="Fan speed", value=1200.0, unit="rpm")
+        assert sv.key == "Fan speed"
+        assert sv.value == pytest.approx(1200.0)
+        assert sv.unit == "rpm"
+
+    def test_null_value(self):
+        sv = StatusValue(key="Pump mode", value=None, unit="")
+        assert sv.value is None
+
+
+class TestMessageStatus:
+    def test_success_value(self):
+        assert MessageStatus.SUCCESS.value == "success"
+
+    def test_error_value(self):
+        assert MessageStatus.ERROR.value == "error"
+
+
+class TestSpeedKwargs:
+    def test_fields(self):
+        sk = SpeedKwargs(channel="fan1", duty=75)
+        assert sk.channel == "fan1"
+        assert sk.duty == 75
+
+
+class TestFixedSpeedRequest:
+    def test_fields(self):
+        req = FixedSpeedRequest(
+            device_id=1, speed_kwargs=SpeedKwargs(channel="fan1", duty=50)
+        )
+        assert req.device_id == 1
+        assert req.speed_kwargs.channel == "fan1"
+        assert req.speed_kwargs.duty == 50
+
+
+class TestLedRequest:
+    def test_fields(self):
+        req = LedRequest(
+            device="Kraken X63",
+            channel="ring",
+            mode="fixed",
+            colors=[[255, 0, 0]],
+        )
+        assert req.device == "Kraken X63"
+        assert req.channel == "ring"
+        assert req.mode == "fixed"
+        assert req.colors == [[255, 0, 0]]
+
+
+class TestPipeRequest:
+    def test_command_only_defaults_data_to_null(self):
+        req = PipeRequest(command="get.statuses")
+        assert req.command == "get.statuses"
+        assert bytes(req.data) == b"null"
+
+    def test_with_explicit_data(self):
+        req = PipeRequest(
+            command="set.fixed_speed", data=msgspec.Raw(b'{"device_id": 1}')
+        )
+        assert b"device_id" in bytes(req.data)
+
+
+class TestBridgeResponse:
+    def test_success_response(self):
+        resp = BridgeResponse(status=MessageStatus.SUCCESS, data=None)
+        assert resp.status == MessageStatus.SUCCESS
+        assert resp.error is None
+
+    def test_error_response(self):
+        resp = BridgeResponse(status=MessageStatus.ERROR, error="something failed")
+        assert resp.status == MessageStatus.ERROR
+        assert resp.error == "something failed"
+
+
+class TestDeviceStatus:
+    def test_fields_with_speed_channels(self):
+        sv = StatusValue(key="Fan speed", value=800.0, unit="rpm")
+        ds = DeviceStatus(
+            id=1,
+            description="Kraken X63",
+            status=[sv],
+            speed_channels=["fan1"],
+        )
+        assert ds.id == 1
+        assert ds.description == "Kraken X63"
+        assert ds.speed_channels == ["fan1"]
+
+    def test_speed_channels_defaults_to_empty(self):
+        ds = DeviceStatus(id=2, description="Something", status=[])
+        assert ds.speed_channels == []
+
+
+class TestExceptions:
+    def test_liquidctl_exception(self):
+        with pytest.raises(LiquidctlException, match="device error"):
+            raise LiquidctlException("device error")
+
+    def test_bad_request_exception(self):
+        with pytest.raises(BadRequestException, match="not found"):
+            raise BadRequestException("not found")
+
+    def test_pipe_error(self):
+        with pytest.raises(PipeError):
+            raise PipeError("pipe broken")
 
 
 class TestModeIsSlave:

--- a/src/liquidctl_server/tests/test_server.py
+++ b/src/liquidctl_server/tests/test_server.py
@@ -71,6 +71,34 @@ class TestMalformedInput:
         assert "Protocol Error" in resp.error
 
 
+class TestSetLed:
+    def test_valid_payload_calls_set_color(self):
+        svc = _mock_service()
+        svc.set_color.return_value = None
+        payload = json.dumps(
+            {
+                "command": "set.led",
+                "data": {
+                    "device": "Kraken X63",
+                    "channel": "ring",
+                    "mode": "fixed",
+                    "colors": [[255, 0, 0], [0, 255, 0]],
+                },
+            }
+        ).encode()
+        resp = _decode(process_request(payload, svc))
+        assert resp.status == MessageStatus.SUCCESS
+        svc.set_color.assert_called_once_with(
+            "Kraken X63", "ring", "fixed", [(255, 0, 0), (0, 255, 0)]
+        )
+
+    def test_null_data_returns_error(self):
+        svc = _mock_service()
+        resp = _decode(process_request(b'{"command":"set.led"}', svc))
+        assert resp.status == MessageStatus.ERROR
+        assert "Missing data" in resp.error
+
+
 class TestHandlerExceptions:
     def test_bad_request_propagates_message(self):
         svc = _mock_service()

--- a/src/liquidctl_server/tests/test_service.py
+++ b/src/liquidctl_server/tests/test_service.py
@@ -1,3 +1,4 @@
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -130,3 +131,131 @@ class TestSetFixedSpeedDeduplication:
         svc.set_fixed_speed(1, {"channel": "pump", "duty": 100})
 
         svc._executor.submit.assert_called_once()
+
+
+def _make_future(return_value=None):
+    mock = MagicMock()
+    mock.result.return_value = return_value
+    return mock
+
+
+class TestContextManager:
+    def test_enter_returns_self(self):
+        svc = _make_service()
+        assert svc.__enter__() is svc
+
+    def test_exit_calls_shutdown(self):
+        svc = _make_service()
+        svc._executor.submit.return_value = _make_future()
+        svc.__exit__(None, None, None)
+        svc._executor.shutdown.assert_called_once()
+
+    def test_exit_does_not_suppress_exception(self):
+        svc = _make_service()
+        svc._executor.submit.return_value = _make_future()
+        result = svc.__exit__(ValueError, ValueError("test"), None)
+        assert not result
+
+
+class TestResolveDeviceId:
+    def test_found_case_insensitive(self):
+        svc = _make_service()
+        dev = MagicMock()
+        dev.description = "NZXT Kraken X63"
+        svc.devices = {1: dev}
+        assert svc._resolve_device_id("kraken") == 1
+
+    def test_not_found_returns_none(self):
+        svc = _make_service()
+        svc.devices = {}
+        assert svc._resolve_device_id("unknown") is None
+
+
+class TestSetColor:
+    def test_success_calls_executor(self):
+        svc = _make_service()
+        dev = MagicMock()
+        dev.description = "Kraken X63"
+        svc.devices = {1: dev}
+        svc._executor.submit.return_value = _make_future()
+
+        svc.set_color("Kraken", "ring", "fixed", [(255, 0, 0)])
+
+        svc._executor.submit.assert_called_once()
+
+    def test_unknown_device_raises(self):
+        svc = _make_service()
+        svc.devices = {}
+        with pytest.raises(BadRequestException, match="No device matching"):
+            svc.set_color("NonExistent", "ring", "fixed", [(255, 0, 0)])
+
+    def test_timeout_is_swallowed(self):
+        svc = _make_service()
+        dev = MagicMock()
+        dev.description = "Kraken X63"
+        svc.devices = {1: dev}
+        future_mock = MagicMock()
+        future_mock.result.side_effect = FuturesTimeoutError()
+        svc._executor.submit.return_value = future_mock
+
+        svc.set_color("Kraken", "ring", "fixed", [(255, 0, 0)])
+
+
+class TestDisconnectAll:
+    def test_calls_disconnect_per_device(self):
+        svc = _make_service()
+        svc.devices = {1: MagicMock(), 2: MagicMock()}
+        svc._executor.submit.return_value = _make_future()
+
+        svc.disconnect_all()
+
+        assert svc._executor.submit.call_count == 2
+
+    def test_exception_is_swallowed(self):
+        svc = _make_service()
+        svc.devices = {1: MagicMock()}
+        future_mock = MagicMock()
+        future_mock.result.side_effect = RuntimeError("USB error")
+        svc._executor.submit.return_value = future_mock
+
+        svc.disconnect_all()
+
+
+class TestShutdown:
+    def test_calls_executor_shutdown_and_clears_state(self):
+        svc = _make_service()
+        svc.devices = {1: MagicMock()}
+        svc.device_status_cache = {1: []}
+        svc.speed_channels = {1: ["fan1"]}
+        svc.previous_duty = {"1_fan1": 50}
+        svc._executor.submit.return_value = _make_future()
+
+        svc.shutdown()
+
+        svc._executor.shutdown.assert_called_once()
+        assert svc.devices == {}
+        assert svc.device_status_cache == {}
+        assert svc.speed_channels == {}
+        assert svc.previous_duty == {}
+
+
+class TestInitializeAll:
+    def test_success_on_first_try(self):
+        svc = _make_service()
+        with patch.object(svc, "_find_devices") as mock_find:
+            svc.initialize_all()
+            mock_find.assert_called_once()
+
+    def test_retries_on_failure_then_succeeds(self):
+        svc = _make_service()
+        call_count = 0
+
+        def fail_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise RuntimeError("init failed")
+
+        with patch.object(svc, "_find_devices", side_effect=fail_then_succeed):
+            svc.initialize_all()
+            assert call_count == 2

--- a/src/liquidctl_server/tests/test_speed_channels.py
+++ b/src/liquidctl_server/tests/test_speed_channels.py
@@ -2,9 +2,15 @@ import pytest
 from liquidctl.driver.commander_core import CommanderCore
 from liquidctl.driver.commander_pro import CommanderPro
 from liquidctl.driver.hydro_platinum import HydroPlatinum
-from liquidctl.driver.smart_device import SmartDevice2
+from liquidctl.driver.smart_device import SmartDevice, SmartDevice2
 
-from liquidctl_server.service.liquidctl_service import HydroPro, LiquidctlService
+from liquidctl_server.service.liquidctl_service import (
+    Aquacomputer,
+    ControlHub,
+    H1V2,
+    HydroPro,
+    LiquidctlService,
+)
 
 
 def _fake(driver_cls, **attrs):
@@ -54,6 +60,39 @@ def test_hydro_platinum_empty_fan_names():
 def test_hydro_pro_uses_fan_count():
     device = _fake(HydroPro, _fan_count=3)
     assert LiquidctlService._get_speed_channels(device) == ["fan1", "fan2", "fan3"]
+
+
+def test_smart_device_uses_speed_channels_keys():
+    device = _fake(SmartDevice, _speed_channels={"fan1": (0, False)})
+    assert LiquidctlService._get_speed_channels(device) == ["fan1"]
+
+
+def test_smart_device2_missing_attr_returns_empty():
+    assert LiquidctlService._get_speed_channels(_fake(SmartDevice2)) == []
+
+
+@pytest.mark.skipif(
+    Aquacomputer is None, reason="Aquacomputer not in this liquidctl version"
+)
+def test_aquacomputer_uses_fan_ctrl_keys():
+    device = _fake(
+        Aquacomputer, _device_info={"fan_ctrl": {"fan1": None, "fan2": None}}
+    )
+    assert LiquidctlService._get_speed_channels(device) == ["fan1", "fan2"]
+
+
+@pytest.mark.skipif(
+    ControlHub is None, reason="ControlHub not in this liquidctl version"
+)
+def test_control_hub_uses_speed_channels_keys():
+    device = _fake(ControlHub, _speed_channels={"fan1": (0, False), "fan2": (1, False)})
+    assert LiquidctlService._get_speed_channels(device) == ["fan1", "fan2"]
+
+
+@pytest.mark.skipif(H1V2 is None, reason="H1V2 not in this liquidctl version")
+def test_h1v2_uses_speed_channels_keys():
+    device = _fake(H1V2, _speed_channels={"fan1": (0, False)})
+    assert LiquidctlService._get_speed_channels(device) == ["fan1"]
 
 
 def main():


### PR DESCRIPTION
## Summary

Raises test coverage on the testable, OS-agnostic layers of both the Python bridge and the C# plugin. The Windows-only named-pipe layer (`pipe_server.py`, `LiquidctlClient` process/pipe I/O) and live-device flows remain out of scope — they need real Windows resources.

### Coverage impact (Python, measured locally)
| Module | Before | After |
|---|---|---|
| `models.py` | ~10% | **100%** |
| `service/liquidctl_service.py` | ~22% | **60%** |
| `service/executor.py` | ~83% | **95%** |
| `server.py` | ~62% | 56%* |
| **TOTAL** | ~33% | **50%** |

\* `server.py` line % dips because new `set.led` branch coverage is offset by counting; the handler itself is now covered.

## Python additions
- **`test_models.py`** — all msgspec structs (`StatusValue`, `SpeedKwargs`, `FixedSpeedRequest`, `LedRequest`, `PipeRequest`, `BridgeResponse`, `DeviceStatus`), `MessageStatus` enum, and exception classes.
- **`test_service.py`** — context manager, `_resolve_device_id`, `set_color` (success/unknown/timeout), `disconnect_all`, `shutdown` state-clearing, `initialize_all` retry.
- **`test_server.py`** — `handle_set_led` success + missing-data error.
- **`test_speed_channels.py`** — `SmartDevice`, `Aquacomputer`, `ControlHub`, `H1V2` drivers + missing-attr fallback.
- **`test_executor.py`** — real `submit`/`shutdown`/`set_number_of_devices` (not mocked).

## .NET additions
- Extracted **`ILiquidctlClient`** so `LiquidCtlPlugin` and `ControlSensor` are unit-testable; `LiquidCtlPlugin` gains an internal injection constructor (public API unchanged).
- **`LiquidctlPluginTests`** — `Load` (temp/fan/duty/authoritative/null), `Update`, `Initialize`, `Close`/`Dispose` via a hand-rolled fake client (no Moq).
- **`ControlSensor` tests** — `Set` payload, float-duty rounding, `Reset`, null-initial no-op, paired sensor id.

## Verification
- Python: `83 passed, 2 skipped` (skips = drivers absent from this liquidctl version) + `ruff` clean.
- .NET: `dotnet build` clean with `TreatWarningsAsErrors` + all analyzers; the Windows-only `[WindowsOnlyFact]` tests will execute on CI's Windows runner.