### PR TITLE
test: cover Windows-only pipe and client layers

### DIFF
--- a/src/FanControl.Liquidctl.Tests/LiquidctlClientTests.cs
+++ b/src/FanControl.Liquidctl.Tests/LiquidctlClientTests.cs
@@ -1,3 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO.Pipes;
+using System.Runtime.Versioning;
+using System.Text;
 using FanControl.Plugins;
 using Xunit;
 
@@ -59,5 +63,96 @@ public sealed class LiquidctlClientTests
         var ex = Record.Exception(() => client.SetFixedSpeed(request));
 
         Assert.Null(ex);
+    }
+
+    // Must stay in this class: xUnit parallelizes across classes, which would
+    // collide on the OS-global pipe name the client hardcodes.
+    private const string PipeName = "LiquidCtlPipe";
+
+    [SupportedOSPlatform("windows")]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+        Justification = "The server is owned and disposed by the returned worker thread via using.")]
+    private static Thread StartOneShotServer(string responseJson, Action<string>? onRequest = null)
+    {
+        var server = new NamedPipeServerStream(
+            PipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Message, PipeOptions.Asynchronous);
+
+        var thread = new Thread(() =>
+        {
+            using (server)
+            {
+                server.WaitForConnection();
+                var buffer = new byte[65536];
+                int read = server.Read(buffer, 0, buffer.Length);
+                onRequest?.Invoke(Encoding.UTF8.GetString(buffer, 0, read));
+
+                byte[] response = Encoding.UTF8.GetBytes(responseJson);
+                server.Write(response, 0, response.Length);
+                server.Flush();
+            }
+        });
+        thread.Start();
+        return thread;
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void GetStatuses_WithRespondingServer_ReturnsParsedStatuses()
+    {
+        const string response = """
+        {"status":"success","data":[{"id":1,"description":"Test Device","status":[{"key":"Fan 1 speed","value":1200,"unit":"rpm"}],"speed_channels":["fan1"]}]}
+        """;
+        var serverThread = StartOneShotServer(response);
+        using var client = new LiquidctlClient(new FakeLogger());
+
+        IReadOnlyList<DeviceStatus> result = client.GetStatuses();
+        serverThread.Join(5000);
+
+        var device = Assert.Single(result);
+        Assert.Equal(1, device.Id);
+        Assert.Equal("Test Device", device.Description);
+        Assert.Equal(["fan1"], device.SpeedChannels);
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void GetStatuses_AfterSuccess_ReturnsCachedWhenRequestFails()
+    {
+        const string response = """
+        {"status":"success","data":[{"id":1,"description":"Cached Device","status":[],"speed_channels":[]}]}
+        """;
+        var serverThread = StartOneShotServer(response);
+        using var client = new LiquidctlClient(new FakeLogger());
+
+        client.GetStatuses();
+        serverThread.Join(5000);
+
+        IReadOnlyList<DeviceStatus> cached = client.GetStatuses();
+
+        Assert.Equal("Cached Device", Assert.Single(cached).Description);
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void SetFixedSpeed_WithServer_SendsSerializedRequest()
+    {
+        string? received = null;
+        using var got = new ManualResetEventSlim(false);
+        var serverThread = StartOneShotServer(
+            """{"status":"success","data":null}""",
+            request => { received = request; got.Set(); });
+
+        using var client = new LiquidctlClient(new FakeLogger());
+        client.SetFixedSpeed(new FixedSpeedRequest
+        {
+            DeviceId = 7,
+            SpeedKwargs = new SpeedKwargs { Channel = "pump", Duty = 80 }
+        });
+
+        Assert.True(got.Wait(5000));
+        serverThread.Join(5000);
+        Assert.Contains("set.fixed_speed", received, StringComparison.Ordinal);
+        Assert.Contains("pump", received, StringComparison.Ordinal);
+        Assert.Contains("80", received, StringComparison.Ordinal);
     }
 }

--- a/src/FanControl.Liquidctl.Tests/LiquidctlClientTests.cs
+++ b/src/FanControl.Liquidctl.Tests/LiquidctlClientTests.cs
@@ -1,0 +1,63 @@
+using FanControl.Plugins;
+using Xunit;
+
+namespace FanControl.LiquidCtl.Tests;
+
+internal sealed class FakeLogger : IPluginLogger
+{
+    public List<string> Messages { get; } = [];
+    public void Log(string message) => Messages.Add(message);
+}
+
+public sealed class LiquidctlClientTests
+{
+    [WindowsOnlyFact]
+    public void State_Initially_Disconnected()
+    {
+        using var client = new LiquidctlClient(new FakeLogger());
+        Assert.Equal(ConnectionState.Disconnected, client.State);
+    }
+
+    [WindowsOnlyFact]
+    public void GetStatuses_WhenDisconnected_ReturnsEmpty()
+    {
+        using var client = new LiquidctlClient(new FakeLogger());
+        Assert.Empty(client.GetStatuses());
+    }
+
+    [WindowsOnlyFact]
+    public void Init_WithMissingBridgeExe_EndsInFaultedState()
+    {
+        using var client = new LiquidctlClient(new FakeLogger());
+
+        client.Init();
+
+        Assert.Equal(ConnectionState.Faulted, client.State);
+    }
+
+    [WindowsOnlyFact]
+    public void Dispose_IsIdempotent()
+    {
+        var client = new LiquidctlClient(new FakeLogger());
+
+        client.Dispose();
+        var ex = Record.Exception(client.Dispose);
+
+        Assert.Null(ex);
+    }
+
+    [WindowsOnlyFact]
+    public void SetFixedSpeed_WhenDisconnected_DoesNotThrow()
+    {
+        using var client = new LiquidctlClient(new FakeLogger());
+        var request = new FixedSpeedRequest
+        {
+            DeviceId = 1,
+            SpeedKwargs = new SpeedKwargs { Channel = "fan1", Duty = 50 }
+        };
+
+        var ex = Record.Exception(() => client.SetFixedSpeed(request));
+
+        Assert.Null(ex);
+    }
+}

--- a/src/liquidctl_server/tests/test_pipe_server.py
+++ b/src/liquidctl_server/tests/test_pipe_server.py
@@ -1,0 +1,140 @@
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="pipe_server uses Win32 named pipe APIs"
+)
+
+if sys.platform == "win32":
+    import ctypes
+    from ctypes import wintypes
+
+    from liquidctl_server.models import PipeError
+    from liquidctl_server.pipe_server import Base, Server
+
+    _GENERIC_READ = 0x80000000
+    _GENERIC_WRITE = 0x40000000
+    _OPEN_EXISTING = 3
+    _PIPE_READMODE_MESSAGE = 0x00000002
+    _INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+
+    # restype must be HANDLE (pointer-sized): the ctypes default of c_int would
+    # truncate the returned 64-bit pipe handle on Win64.
+    ctypes.windll.kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    ctypes.windll.kernel32.CreateFileW.restype = wintypes.HANDLE
+    ctypes.windll.kernel32.SetNamedPipeHandleState.restype = wintypes.BOOL
+
+
+class _PipeClient:
+    def __init__(self, pipe_path: str) -> None:
+        self._k32 = ctypes.windll.kernel32
+        self.handle = self._connect(pipe_path)
+
+    def _connect(self, pipe_path: str) -> int:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            handle = self._k32.CreateFileW(
+                pipe_path,
+                _GENERIC_READ | _GENERIC_WRITE,
+                0,
+                None,
+                _OPEN_EXISTING,
+                0,
+                None,
+            )
+            if handle != _INVALID_HANDLE_VALUE:
+                mode = wintypes.DWORD(_PIPE_READMODE_MESSAGE)
+                self._k32.SetNamedPipeHandleState(
+                    handle, ctypes.byref(mode), None, None
+                )
+                return handle
+            time.sleep(0.05)
+        raise AssertionError(f"could not connect to {pipe_path}")
+
+    def write(self, payload: bytes) -> None:
+        written = wintypes.DWORD(0)
+        self._k32.WriteFile(
+            self.handle, payload, len(payload), ctypes.byref(written), None
+        )
+
+    def read(self, size: int = 65536) -> bytes:
+        buffer = ctypes.create_string_buffer(size)
+        read_bytes = wintypes.DWORD(0)
+        self._k32.ReadFile(self.handle, buffer, size, ctypes.byref(read_bytes), None)
+        return buffer.raw[: read_bytes.value]
+
+    def close(self) -> None:
+        if self.handle:
+            ctypes.windll.kernel32.CloseHandle(self.handle)
+            self.handle = None
+
+
+class TestBaseWithoutConnection:
+    def test_fresh_base_is_not_alive(self):
+        assert Base().alive is False
+
+    def test_canread_false_when_not_alive(self):
+        assert Base().canread() is False
+
+    def test_read_none_when_not_alive(self):
+        assert Base().read() is None
+
+    def test_write_raises_when_not_alive(self):
+        with pytest.raises(PipeError):
+            Base().write(b"data")
+
+
+def _wait_until(predicate, timeout: float = 3.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+class TestServerLoopback:
+    def test_client_to_server_roundtrip(self):
+        server = Server(name="LiquidCtlPipeTest_RX")
+        client = None
+        try:
+            client = _PipeClient(server.pipe_path)
+            assert _wait_until(lambda: server.alive)
+
+            client.write(b'{"command":"get.statuses"}')
+            assert _wait_until(server.canread)
+
+            assert server.read() == b'{"command":"get.statuses"}'
+        finally:
+            server.close()
+            if client is not None:
+                client.close()
+
+    def test_server_to_client_roundtrip(self):
+        server = Server(name="LiquidCtlPipeTest_TX")
+        client = None
+        try:
+            client = _PipeClient(server.pipe_path)
+            assert _wait_until(lambda: server.alive)
+
+            assert server.write(b'{"status":"success"}') is True
+            assert client.read() == b'{"status":"success"}'
+        finally:
+            server.close()
+            if client is not None:
+                client.close()
+
+    def test_context_manager_closes_server(self):
+        with Server(name="LiquidCtlPipeTest_CM") as server:
+            assert server.server_thread.is_alive()
+        assert server.shutdown_event.is_set()

--- a/src/liquidctl_server/tests/test_server.py
+++ b/src/liquidctl_server/tests/test_server.py
@@ -1,9 +1,19 @@
+import contextlib
 import json
-from unittest.mock import MagicMock
+import logging
+import sys
+from unittest.mock import MagicMock, patch
 
 import msgspec
+import pytest
 
-from liquidctl_server.models import BadRequestException, BridgeResponse, MessageStatus
+from liquidctl_server import server
+from liquidctl_server.models import (
+    BadRequestException,
+    BridgeResponse,
+    MessageStatus,
+    PipeError,
+)
 from liquidctl_server.server import process_request
 
 
@@ -113,3 +123,111 @@ class TestHandlerExceptions:
         resp = _decode(process_request(b'{"command":"get.statuses"}', svc))
         assert resp.status == MessageStatus.ERROR
         assert "Internal Error" in resp.error
+
+
+class TestSetupLogging:
+    def test_known_level_passed_to_basicconfig(self):
+        with patch("liquidctl_server.server.logging.basicConfig") as mock_bc:
+            server.setup_logging("DEBUG")
+        assert mock_bc.call_args.kwargs["level"] == logging.DEBUG
+
+    def test_unknown_level_falls_back_to_info(self):
+        with patch("liquidctl_server.server.logging.basicConfig") as mock_bc:
+            server.setup_logging("NOPE")
+        assert mock_bc.call_args.kwargs["level"] == logging.INFO
+
+
+def _fake_pipe(messages):
+    pipe = MagicMock()
+    pipe.shutdown_event.is_set.side_effect = [False] * len(messages) + [True]
+    pipe.read.side_effect = messages
+    return pipe
+
+
+class TestRunServerLoop:
+    def test_message_is_processed_and_response_written(self):
+        pipe = _fake_pipe([b'{"command":"get.statuses"}'])
+        server.run_server_loop(_mock_service(), pipe)
+        pipe.write.assert_called_once()
+
+    def test_empty_read_sleeps_without_writing(self):
+        pipe = _fake_pipe([None])
+        with patch("liquidctl_server.server.time.sleep") as mock_sleep:
+            server.run_server_loop(_mock_service(), pipe)
+        mock_sleep.assert_called_once()
+        pipe.write.assert_not_called()
+
+    def test_pipe_error_on_write_is_swallowed(self):
+        pipe = _fake_pipe([b'{"command":"get.statuses"}'])
+        pipe.write.side_effect = PipeError("client gone")
+        server.run_server_loop(_mock_service(), pipe)
+
+
+def _make_context_manager(mock_cls):
+    mock_cls.return_value.__enter__.return_value = mock_cls.return_value
+    mock_cls.return_value.__exit__.return_value = False
+
+
+@contextlib.contextmanager
+def _patched_main():
+    with (
+        patch("liquidctl_server.server.LiquidctlService") as service_cls,
+        patch("liquidctl_server.server.Server") as server_cls,
+        patch("liquidctl_server.server.run_server_loop") as run_loop,
+        patch("liquidctl_server.server.setup_logging") as setup_logging,
+        patch("liquidctl_server.server.threading.Thread"),
+    ):
+        _make_context_manager(service_cls)
+        _make_context_manager(server_cls)
+        yield {
+            "LiquidctlService": service_cls,
+            "Server": server_cls,
+            "run_server_loop": run_loop,
+            "setup_logging": setup_logging,
+        }
+
+
+class TestMain:
+    def test_initializes_service_and_runs_loop(self):
+        with _patched_main() as mocks, patch.object(sys, "argv", ["prog"]):
+            server.main()
+        mocks["LiquidctlService"].return_value.initialize_all.assert_called_once()
+        mocks["run_server_loop"].assert_called_once()
+
+    def test_default_pipe_names(self):
+        with _patched_main() as mocks, patch.object(sys, "argv", ["prog"]):
+            server.main()
+        names = [c.kwargs["name"] for c in mocks["Server"].call_args_list]
+        assert names == ["LiquidCtlPipe", "LiquidCtlPipeRgb"]
+
+    def test_test_flag_adds_suffix(self):
+        with _patched_main() as mocks, patch.object(sys, "argv", ["prog", "--test"]):
+            server.main()
+        names = [c.kwargs["name"] for c in mocks["Server"].call_args_list]
+        assert names == ["LiquidCtlPipeTest", "LiquidCtlPipeTestRgb"]
+
+    def test_env_var_overrides_log_level(self):
+        with (
+            _patched_main() as mocks,
+            patch.object(sys, "argv", ["prog", "--log-level", "INFO"]),
+            patch.dict("os.environ", {"LIQUIDCTL_BRIDGE_LOG": "DEBUG"}),
+        ):
+            server.main()
+        mocks["setup_logging"].assert_called_once_with("DEBUG")
+
+    def test_keyboard_interrupt_is_handled(self):
+        with _patched_main() as mocks, patch.object(sys, "argv", ["prog"]):
+            mocks["run_server_loop"].side_effect = KeyboardInterrupt
+            server.main()
+
+    def test_pipe_error_is_handled(self):
+        with _patched_main() as mocks, patch.object(sys, "argv", ["prog"]):
+            mocks["run_server_loop"].side_effect = PipeError("closed")
+            server.main()
+
+    def test_fatal_exception_exits_with_code_1(self):
+        with _patched_main() as mocks, patch.object(sys, "argv", ["prog"]):
+            mocks["run_server_loop"].side_effect = RuntimeError("boom")
+            with pytest.raises(SystemExit) as exc_info:
+                server.main()
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

Follow-up to the coverage expansion now merged into `develop`. Since CI runs on `windows-latest`, the Windows-only layers that were previously excluded **can** be exercised on the runners — this PR adds real tests for them. Both suites skip on non-Windows dev machines and execute on CI.

## Python — `tests/test_pipe_server.py`
Covers the previously-0% `pipe_server.py` (Win32 named-pipe layer):
- `Base` guards: `read`/`canread`/`write` when the handle isn't alive (`write` raises `PipeError`).
- `Server` loopback: a minimal ctypes client connects to the real named pipe and exercises **both directions** (client→server `read`, server→client `write`), plus context-manager shutdown. This drives `serverentry` → `_create_pipe` → `_wait_for_client` → `_handle_client_session` → `close`.

> Note: the client sets `CreateFileW.restype = HANDLE` explicitly — ctypes' default `c_int` would truncate the 64-bit pipe handle on Win64.

## .NET — `LiquidctlClientTests.cs`
Covers `LiquidctlClient` paths that don't need a live bridge:
- default `Disconnected` state
- `GetStatuses()` returns empty when disconnected
- `Init()` ends in `Faulted` when the bridge exe is missing (exercises the retry loop + `EnsureProcessStarted`)
- `Dispose()` is idempotent
- `SetFixedSpeed()` doesn't throw when disconnected

## Verification
- Local (macOS): C# builds clean (`TreatWarningsAsErrors` + all analyzers); `ruff` clean; pytest passes with the Windows-only tests skipped.
- The Windows-only tests (`[WindowsOnlyFact]` / `skipif win32`) execute on the CI Windows runners.