### PR TITLE
feat(bridge): optional device-name filter

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -16,6 +16,7 @@ A FanControl plugin that integrates [liquidctl](https://github.com/liquidctl/liq
 - **Seamless Integration**: Works natively with FanControl's interface
 - **Error Recovery**: Automatic refresh and recovery from communication errors
 - **Auto-Linking**: Automatically pairs control sensors with their corresponding speed sensors
+- **Device Filtering**: Optionally restrict which devices the plugin claims, leaving the rest free for other tools (e.g. OpenRGB)
 
 ## Tested Devices
 
@@ -79,6 +80,25 @@ Besides fans and pumps, the bridge exposes an RGB endpoint so another process ca
 
 This powers the NZXT command sink in [FanControl.Rgb](https://github.com/6wheels/FanControlPlugins): NZXT RGB reacts to FanControl sensors while liquidctl stays the sole owner of the HID.
 
+### Filtering Devices
+
+By default the plugin claims **every** liquidctl-supported device it finds. Since
+claiming a device takes exclusive ownership of it, this can prevent other tools
+(such as OpenRGB controlling an ASUS Aura controller) from using it.
+
+To limit which devices the plugin connects to, drop a file named
+`liquidctl_filter.txt` in the plugin folder (the same folder that contains the
+plugin `.dll`). Its first non-empty line is used as a **case-insensitive regex**
+matched against each device's description; only matching devices are connected,
+the rest are left untouched. Lines starting with `#` are treated as comments.
+
+```text
+# liquidctl_filter.txt — only connect NZXT devices
+NZXT
+```
+
+If the file is absent or empty, all devices are connected (default behavior).
+
 ## Screenshots
 
 ![Fluid temperature sensor](/docs/images/FluidTemp.png)
@@ -98,6 +118,11 @@ This powers the NZXT command sink in [FanControl.Rgb](https://github.com/6wheels
 - Verify your device is [supported by liquidctl](https://github.com/liquidctl/liquidctl#supported-devices)
 - Try running liquidctl directly from command line to test device connectivity
 - Check Windows Device Manager for any driver issues
+- If you added a `liquidctl_filter.txt`, make sure its regex matches your device description (see [Filtering Devices](#filtering-devices))
+
+### Device Conflicts With Other Tools
+
+- If another tool (e.g. OpenRGB) can no longer control a device after the plugin starts, the plugin has claimed it. Use a [`liquidctl_filter.txt`](#filtering-devices) to exclude that device instead of relying on application start order
 
 ### Communication Errors
 

--- a/src/liquidctl_server/liquidctl_server/service/config.py
+++ b/src/liquidctl_server/liquidctl_server/service/config.py
@@ -17,9 +17,15 @@ MAX_INIT_RETRIES: int = 3
 DEVICE_FILTER_FILE: str = "liquidctl_filter.txt"
 
 
+def _is_bundled() -> bool:
+    """True when running as the built bridge exe (Nuitka or PyInstaller)."""
+    # PyInstaller sets sys.frozen; Nuitka injects __compiled__ into each module.
+    return getattr(sys, "frozen", False) or "__compiled__" in globals()
+
+
 def _plugin_dir() -> Optional[str]:
-    """Plugin folder (parent of the bridge exe folder), or None when not frozen."""
-    if not getattr(sys, "frozen", False):
+    """Plugin folder (parent of the bridge exe folder), or None in source runs."""
+    if not _is_bundled():
         return None
     return os.path.dirname(os.path.dirname(sys.executable))
 

--- a/src/liquidctl_server/liquidctl_server/service/config.py
+++ b/src/liquidctl_server/liquidctl_server/service/config.py
@@ -1,3 +1,56 @@
+import logging
+import os
+import re
+import sys
+from typing import Optional, Pattern
+
+logger = logging.getLogger(__name__)
+
 DEVICE_OPERATION_TIMEOUT: float = 5.0
 DEVICE_STATUS_TIMEOUT: float = 0.5
 MAX_INIT_RETRIES: int = 3
+
+# Optional device allowlist. Drop a file with this name in the plugin folder
+# containing a single regex line; only devices whose description matches
+# (case-insensitive) are connected. Absent file = all devices. Blank lines and
+# lines starting with '#' are ignored.
+DEVICE_FILTER_FILE: str = "liquidctl_filter.txt"
+
+
+def _plugin_dir() -> Optional[str]:
+    """Plugin folder (parent of the bridge exe folder), or None when not frozen."""
+    if not getattr(sys, "frozen", False):
+        return None
+    return os.path.dirname(os.path.dirname(sys.executable))
+
+
+def _read_filter_pattern() -> Optional[str]:
+    """Return the first non-empty, non-comment line of the filter file, if any."""
+    plugin_dir = _plugin_dir()
+    if plugin_dir is None:
+        return None
+    path = os.path.join(plugin_dir, DEVICE_FILTER_FILE)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    logger.info("Using device filter from %s: %r", path, line)
+                    return line
+    except OSError as err:
+        logger.warning("Could not read device filter %s: %s", path, err)
+    return None
+
+
+def load_device_filter() -> Optional[Pattern[str]]:
+    """Compile the configured device-description filter, or None if not set."""
+    pattern = _read_filter_pattern()
+    if not pattern:
+        return None
+    try:
+        return re.compile(pattern, re.IGNORECASE)
+    except re.error as err:
+        logger.error("Invalid device filter regex %r: %s", pattern, err)
+        return None

--- a/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
+++ b/src/liquidctl_server/liquidctl_server/service/liquidctl_service.py
@@ -43,6 +43,7 @@ from liquidctl_server.service.config import (
     DEVICE_OPERATION_TIMEOUT,
     DEVICE_STATUS_TIMEOUT,
     MAX_INIT_RETRIES,
+    load_device_filter,
 )
 from liquidctl_server.service.executor import DeviceExecutor
 
@@ -97,6 +98,18 @@ class LiquidctlService:
 
         if not found_devices:
             logger.info("No Liquidctl devices detected")
+            return
+
+        device_filter = load_device_filter()
+        if device_filter is not None:
+            kept = [d for d in found_devices if device_filter.search(d.description)]
+            skipped = [d.description for d in found_devices if d not in kept]
+            if skipped:
+                logger.info(f"Devices skipped by filter: {skipped}")
+            found_devices = kept
+
+        if not found_devices:
+            logger.info("No Liquidctl devices left after filtering")
             return
 
         self._executor.set_number_of_devices(len(found_devices))

--- a/src/liquidctl_server/tests/test_config.py
+++ b/src/liquidctl_server/tests/test_config.py
@@ -1,0 +1,84 @@
+import os
+import sys
+
+from liquidctl_server.service import config
+
+
+class TestIsBundled:
+    def test_source_run_is_not_bundled(self, monkeypatch):
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(config, "__compiled__", raising=False)
+        assert config._is_bundled() is False
+
+    def test_pyinstaller_frozen_is_bundled(self, monkeypatch):
+        monkeypatch.delattr(config, "__compiled__", raising=False)
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        assert config._is_bundled() is True
+
+    def test_nuitka_compiled_is_bundled(self, monkeypatch):
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.setattr(config, "__compiled__", True, raising=False)
+        assert config._is_bundled() is True
+
+
+class TestPluginDir:
+    def test_source_run_returns_none(self, monkeypatch):
+        monkeypatch.setattr(config, "_is_bundled", lambda: False)
+        assert config._plugin_dir() is None
+
+    def test_bundled_returns_parent_of_exe_dir(self, monkeypatch):
+        monkeypatch.setattr(config, "_is_bundled", lambda: True)
+        exe = os.path.join("plugins", "liquidctl_server", "liquidctl_server.exe")
+        monkeypatch.setattr(sys, "executable", exe)
+        assert config._plugin_dir() == "plugins"
+
+
+class TestReadFilterPattern:
+    def test_no_plugin_dir_returns_none(self, monkeypatch):
+        monkeypatch.setattr(config, "_plugin_dir", lambda: None)
+        assert config._read_filter_pattern() is None
+
+    def test_missing_file_returns_none(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config, "_plugin_dir", lambda: str(tmp_path))
+        assert config._read_filter_pattern() is None
+
+    def test_first_real_line_returned_skipping_comments(self, monkeypatch, tmp_path):
+        (tmp_path / config.DEVICE_FILTER_FILE).write_text(
+            "# comment\n\n  NZXT  \nCorsair\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(config, "_plugin_dir", lambda: str(tmp_path))
+        assert config._read_filter_pattern() == "NZXT"
+
+    def test_comments_only_returns_none(self, monkeypatch, tmp_path):
+        (tmp_path / config.DEVICE_FILTER_FILE).write_text(
+            "# only a comment\n\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(config, "_plugin_dir", lambda: str(tmp_path))
+        assert config._read_filter_pattern() is None
+
+    def test_os_error_returns_none(self, monkeypatch, tmp_path):
+        (tmp_path / config.DEVICE_FILTER_FILE).write_text("NZXT\n", encoding="utf-8")
+        monkeypatch.setattr(config, "_plugin_dir", lambda: str(tmp_path))
+
+        def boom(*args, **kwargs):
+            raise OSError("cannot read")
+
+        monkeypatch.setattr("builtins.open", boom)
+        assert config._read_filter_pattern() is None
+
+
+class TestLoadDeviceFilter:
+    def test_no_pattern_returns_none(self, monkeypatch):
+        monkeypatch.setattr(config, "_read_filter_pattern", lambda: None)
+        assert config.load_device_filter() is None
+
+    def test_valid_pattern_is_case_insensitive(self, monkeypatch):
+        monkeypatch.setattr(config, "_read_filter_pattern", lambda: "NZXT")
+        compiled = config.load_device_filter()
+        assert compiled is not None
+        assert compiled.search("nzxt kraken x63")
+        assert compiled.search("ASUS Aura LED Controller") is None
+
+    def test_invalid_regex_returns_none(self, monkeypatch):
+        monkeypatch.setattr(config, "_read_filter_pattern", lambda: "[")
+        assert config.load_device_filter() is None

--- a/src/liquidctl_server/tests/test_service.py
+++ b/src/liquidctl_server/tests/test_service.py
@@ -1,3 +1,5 @@
+import logging
+import re
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from unittest.mock import MagicMock, patch
 
@@ -259,3 +261,70 @@ class TestInitializeAll:
         with patch.object(svc, "_find_devices", side_effect=fail_then_succeed):
             svc.initialize_all()
             assert call_count == 2
+
+
+def _device(description):
+    dev = MagicMock()
+    dev.description = description
+    return dev
+
+
+class TestFindDevicesFilter:
+    def _run(self, svc, devices, filter_obj):
+        with (
+            patch(
+                "liquidctl_server.service.liquidctl_service.liquidctl"
+                ".find_liquidctl_devices",
+                return_value=devices,
+            ),
+            patch(
+                "liquidctl_server.service.liquidctl_service.load_device_filter",
+                return_value=filter_obj,
+            ),
+            patch.object(svc, "_connect_device"),
+        ):
+            svc._find_devices()
+
+    def test_no_filter_connects_all(self):
+        svc = _make_service()
+        devices = [_device("NZXT Kraken X63"), _device("ASUS Aura LED Controller")]
+
+        self._run(svc, devices, None)
+
+        assert len(svc.devices) == 2
+        svc._executor.set_number_of_devices.assert_called_once_with(2)
+
+    def test_filter_keeps_only_matching(self, caplog):
+        svc = _make_service()
+        aura = _device("ASUS Aura LED Controller")
+        devices = [_device("NZXT Kraken X63"), aura]
+
+        with caplog.at_level(
+            logging.INFO, logger="liquidctl_server.service.liquidctl_service"
+        ):
+            self._run(svc, devices, re.compile("NZXT", re.IGNORECASE))
+
+        assert [d.description for d in svc.devices.values()] == ["NZXT Kraken X63"]
+        svc._executor.set_number_of_devices.assert_called_once_with(1)
+        assert "Devices skipped by filter" in caplog.text
+
+    def test_filter_matching_all_logs_no_skip(self, caplog):
+        svc = _make_service()
+        devices = [_device("NZXT Kraken X63"), _device("NZXT Smart Device V2")]
+
+        with caplog.at_level(
+            logging.INFO, logger="liquidctl_server.service.liquidctl_service"
+        ):
+            self._run(svc, devices, re.compile("NZXT", re.IGNORECASE))
+
+        assert len(svc.devices) == 2
+        assert "Devices skipped by filter" not in caplog.text
+
+    def test_filter_removing_all_returns_early(self):
+        svc = _make_service()
+        devices = [_device("ASUS Aura LED Controller")]
+
+        self._run(svc, devices, re.compile("NZXT", re.IGNORECASE))
+
+        assert svc.devices == {}
+        svc._executor.set_number_of_devices.assert_not_called()


### PR DESCRIPTION
## Summary

Adds an optional allowlist so the bridge only connects to devices matching a user-supplied regex, leaving the rest free for other tools (e.g. OpenRGB controlling an ASUS Aura controller).

Without this, the bridge claims **every** liquidctl-supported device on startup. Claiming takes exclusive ownership of the HID, so a device like the ASUS Aura controller becomes unusable by OpenRGB unless OpenRGB happens to start first — a fragile start-order race.

## How it works

- Drop a `liquidctl_filter.txt` file in the plugin folder (same folder as the `.dll`).
- Its first non-empty, non-comment line is used as a **case-insensitive regex** matched against each device's description.
- Only matching devices are connected; the rest are never opened (filter runs *before* `connect()`, so no USB claim happens).
- Absent/empty file → all devices connected (unchanged default behavior).

Example (`liquidctl_filter.txt`):
```text
# only connect NZXT devices
NZXT
```

## Notes

- The plugin folder is resolved from the bundled exe location. Detection covers **both** Nuitka (`__compiled__`) and PyInstaller (`sys.frozen`); the release build uses Nuitka. In source runs the filter is inactive by design.
- README updated: feature bullet, "Filtering Devices" usage section, and troubleshooting entries.